### PR TITLE
FCM fix

### DIFF
--- a/lib/gcm.js
+++ b/lib/gcm.js
@@ -13,7 +13,7 @@ function GCM(apiKey) {
     this.gcmOptions = {
         host: 'fcm.googleapis.com',
         port: 443,
-        path: '/gcm/send',
+        path: '/fcm/send',
         method: 'POST',
         headers: {}
     };


### PR DESCRIPTION
Missed switching to /fcm/send in the documentation https://developers.google.com/cloud-messaging/android/android-migrate-fcm